### PR TITLE
Add libasan_assert_fail

### DIFF
--- a/KDToolBox.pro
+++ b/KDToolBox.pro
@@ -1,4 +1,4 @@
 TEMPLATE = subdirs
 SUBDIRS += \
+    general \
     qt \
-

--- a/general/asan_assert_fail/README.md
+++ b/general/asan_assert_fail/README.md
@@ -1,0 +1,37 @@
+ASAN assert_fail
+===========
+
+The `asan_assert_fail` library can be preloaded to any application compiled with
+ASAN support enabled to get fancy backtraces for assertion failures.
+
+Example Usage
+==============
+
+```
+$ cat test-asan.cpp
+#include <cassert>
+
+int main(int argc, char **argv)
+{
+    assert(argc == 2);
+    return 0;
+}
+$ g++ -fsanitize=address test-asan.cpp -o test-asan
+$ ./test-asan
+test-asan: test.cpp:5: int main(int, char**): Assertion `argc == 2' failed.
+Aborted (core dumped)
+$ LD_PRELOAD="$(readlink -f /usr/lib/libasan.so) $(readlink -f path/to/libasan_assert_fail.so)" ./test-asan
+test-asan: test.cpp:5: int main(int, char**): Assertion `argc == 2' failed.
+=================================================================
+==241773==ERROR: AddressSanitizer: unknown-crash on address 0x000000000000 at pc 0x7ffd5a782050 bp 0x7ffd5a781ff0 sp 0x7ffd5a781ff0
+READ of size 1 at 0x000000000000 thread T0
+    #0 0x7ffd5a78204f  ([stack]+0x1f04f)
+    #1 0x7f61a199cd0f in __asan::ErrorDescription::Print() /build/gcc/src/gcc/libsanitizer/asan/asan_errors.h:420
+    #2 0x7f61a199cd0f in __asan::ScopedInErrorReport::~ScopedInErrorReport() /build/gcc/src/gcc/libsanitizer/asan/asan_report.cc:140
+    #3 0x7f61a199c668 in __asan::ReportGenericError(unsigned long, unsigned long, unsigned long, unsigned long, bool, unsigned long, unsigned int, bool) /build/gcc/src/gcc/libsanitizer/asan/asan_report.cc:458
+    #4 0x7f61a199c773 in __asan_report_error /build/gcc/src/gcc/libsanitizer/asan/asan_report.cc:473
+    #5 0x7f61a187ec4c in __assert_fail (/home/milian/projects/kdab/KDToolBox/build/debug/asan_assert_fail/libasan_assert_fail.so.1.0.0+0xc4c)
+    #6 0x560b69653981 in main (/tmp/test-asan+0x981)
+    #7 0x7f61a133a022 in __libc_start_main (/usr/lib/libc.so.6+0x27022)
+    #8 0x560b6965387d in _start (/tmp/test-asan+0x87d)
+```

--- a/general/asan_assert_fail/asan_assert_fail.c
+++ b/general/asan_assert_fail/asan_assert_fail.c
@@ -1,0 +1,41 @@
+/****************************************************************************
+**                                MIT License
+**
+** Copyright (C) 2020 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+** Author: Milian Wolff <milian.wolff@kdab.com>
+**
+** This file is part of KDToolBox (https://github.com/KDAB/KDToolBox).
+**
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and associated documentation files (the "Software"), to deal
+** in the Software without restriction, including without limitation the rights
+** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+** copies of the Software, ** and to permit persons to whom the Software is
+** furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice (including the next paragraph)
+** shall be included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF ** CONTRACT, TORT OR OTHERWISE,
+** ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+****************************************************************************/
+
+#include <sanitizer/asan_interface.h>
+
+#include <stdio.h>
+
+extern const char *__progname;
+
+void __assert_fail(const char *assertion, const char *file,
+                   unsigned int line, const char *function)
+{
+    int stack_var = 0;
+    fprintf(stderr, "%s: %s:%d: %s: Assertion `%s' failed.\n", __progname, file, line, function, assertion);
+    __asan_report_error(__builtin_frame_address(0), &stack_var, &stack_var, NULL, 0, 1);
+    std::abort();
+}

--- a/general/asan_assert_fail/asan_assert_fail.pro
+++ b/general/asan_assert_fail/asan_assert_fail.pro
@@ -1,0 +1,5 @@
+TEMPLATE = lib
+
+QT -= core gui
+CONFIG += use_c_linker sanitizer sanitize_address
+SOURCES = asan_assert_fail.c

--- a/general/general.pro
+++ b/general/general.pro
@@ -1,0 +1,6 @@
+TEMPLATE = subdirs
+
+linux {
+    SUBDIRS += \
+        asan_assert_fail
+}

--- a/qt/asan_assert_fail_qt/README.md
+++ b/qt/asan_assert_fail_qt/README.md
@@ -1,0 +1,37 @@
+ASAN assert_fail
+===========
+
+The `asan_assert_fail_qt` library can be preloaded to any application compiled with
+ASAN support enabled to get fancy backtraces for assertion failures:
+
+Example Usage
+==============
+
+```
+$ cat test-asan.cpp
+#include <qglobal.h>
+
+int main(int argc, char **argv)
+{
+    Q_ASSERT(argc == 2);
+    return 0;
+}
+$ g++ -fsanitize=address -fPIC -lQt5Core -I/usr/include/qt -I/usr/include/qt/QtCore test-asan.cpp -o test-asan
+$ ./test-asan
+0.000 fatal: unknown[test_qt.cpp:5]: ASSERT: "argc == 2" in file test_qt.cpp, line 5
+Aborted (core dumped)
+$ LD_PRELOAD="$(readlink -f /usr/lib/libasan.so) $(readlink -f path/to/libasan_assert_fail_qt.so)" ./test-asan
+0.000 warning: unknown[unknown:0]: ASSERT: "argc == 2" in file test_qt.cpp, line 5
+=================================================================
+==247141==ERROR: AddressSanitizer: unknown-crash on address 0x000000000000 at pc 0x7ffc24e13ec0 bp 0x7ffc24e13e40 sp 0x7ffc24e13e40
+READ of size 1 at 0x000000000000 thread T0
+    #0 0x7ffc24e13ebf  ([stack]+0x1eebf)
+    #1 0x7fa8e75bad0f in __asan::ErrorDescription::Print() /build/gcc/src/gcc/libsanitizer/asan/asan_errors.h:420
+    #2 0x7fa8e75bad0f in __asan::ScopedInErrorReport::~ScopedInErrorReport() /build/gcc/src/gcc/libsanitizer/asan/asan_report.cc:140
+    #3 0x7fa8e75ba668 in __asan::ReportGenericError(unsigned long, unsigned long, unsigned long, unsigned long, bool, unsigned long, unsigned int, bool) /build/gcc/src/gcc/libsanitizer/asan/asan_report.cc:458
+    #4 0x7fa8e75ba773 in __asan_report_error /build/gcc/src/gcc/libsanitizer/asan/asan_report.cc:473
+    #5 0x7fa8e749d1a6 in qt_assert(char const*, char const*, int) (/home/milian/projects/kdab/KDToolBox/build/qt/asan_assert_fail_qt/libasan_assert_fail_qt.so.1.0.0+0x11a6)
+    #6 0x556cb2b43715 in main (/tmp/a.out+0x715)
+    #7 0x7fa8e6a1d022 in __libc_start_main (/usr/lib/libc.so.6+0x27022)
+    #8 0x556cb2b4361d in _start (/tmp/a.out+0x61d)
+```

--- a/qt/asan_assert_fail_qt/asan_assert_fail_qt.cpp
+++ b/qt/asan_assert_fail_qt/asan_assert_fail_qt.cpp
@@ -1,0 +1,42 @@
+/****************************************************************************
+**                                MIT License
+**
+** Copyright (C) 2020 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+** Author: Milian Wolff <milian.wolff@kdab.com>
+**
+** This file is part of KDToolBox (https://github.com/KDAB/KDToolBox).
+**
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and associated documentation files (the "Software"), to deal
+** in the Software without restriction, including without limitation the rights
+** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+** copies of the Software, ** and to permit persons to whom the Software is
+** furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice (including the next paragraph)
+** shall be included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF ** CONTRACT, TORT OR OTHERWISE,
+** ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+****************************************************************************/
+
+#include <sanitizer/asan_interface.h>
+
+#include <QDebug>
+
+Q_DECL_EXPORT void qt_assert(const char *assertion, const char *file, int line) noexcept
+{
+    int stack_var = 0;
+    qWarning("ASSERT: \"%s\" in file %s, line %d", assertion, file, line);
+    __asan_report_error(__builtin_frame_address(0), &stack_var, &stack_var, NULL, 0, 1);
+    std::abort();
+}
+
+extern "C" {
+#include "../../general/asan_assert_fail/asan_assert_fail.c"
+}

--- a/qt/asan_assert_fail_qt/asan_assert_fail_qt.pro
+++ b/qt/asan_assert_fail_qt/asan_assert_fail_qt.pro
@@ -1,0 +1,5 @@
+TEMPLATE = lib
+
+QT -= gui
+CONFIG += sanitizer sanitize_address
+SOURCES = asan_assert_fail_qt.cpp

--- a/qt/qt.pro
+++ b/qt/qt.pro
@@ -4,3 +4,7 @@ SUBDIRS += \
     qml \
     ui_watchdog \
 
+linux {
+    SUBDIRS += \
+        asan_assert_fail_qt
+}


### PR DESCRIPTION
This is a utility library that can be LD_PRELOAD'ed to get
ASAN backtraces shown when an assertion fails.