### PR TITLE
Turn off single shot for throttlers

### DIFF
--- a/qt/KDSignalThrottler/src/KDSignalThrottler.cpp
+++ b/qt/KDSignalThrottler/src/KDSignalThrottler.cpp
@@ -37,7 +37,7 @@ KDGenericSignalThrottler::KDGenericSignalThrottler(Kind kind,
     , m_emissionPolicy(emissionPolicy)
     , m_hasPendingEmission(false)
 {
-    m_timer.setSingleShot(true);
+    m_timer.setSingleShot(m_kind == Kind::Debouncer);
     connect(&m_timer, &QTimer::timeout, this, &KDGenericSignalThrottler::maybeEmitTriggered);
 }
 
@@ -123,6 +123,8 @@ void KDGenericSignalThrottler::maybeEmitTriggered()
 {
     if (m_hasPendingEmission)
         emitTriggered();
+    else
+        m_timer.stop();
 }
 
 void KDGenericSignalThrottler::emitTriggered()


### PR DESCRIPTION
For a leading throttler, you can get two signals emitted at each
interval if the input rate is faster than the timeout. This is because
right after the the timer goes off, the next throttle request will
immediately trigger. By turning off the timer's single shot status, we
can prevent signals that would've emitted right after a timeout.